### PR TITLE
Feat remove cloud front

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ This module is designed to be used with `DNXLabs/terraform-aws-ecs`.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
+| alb_only | Whether to deploy only an alb and no cloudFront or not with the cluster | string | `"false"` | no |
 | alb\_dns\_name | ALB DNS Name that CloudFront will point as origin | string | n/a | yes |
 | alb\_listener\_https\_arn | ALB HTTPS Listener created by ECS cluster module | string | n/a | yes |
 | autoscaling\_cpu | Enables autoscaling based on average CPU tracking | string | `"false"` | no |

--- a/_variables.tf
+++ b/_variables.tf
@@ -152,7 +152,7 @@ variable "healthcheck_matcher" {
   description = "The HTTP codes to use when checking for a successful response from a target"
 }
 
-variable "alb-only" {
+variable "alb_only" {
   default     = false
   description = "Whether to deploy only an alb and no cloudFront or not with the cluster"
 }

--- a/_variables.tf
+++ b/_variables.tf
@@ -27,6 +27,15 @@ variable "path" {
   description = "Optional path to use on listener rule"
 }
 
+variable "hosted_zone" {
+  default     = ""
+  description = "Hosted Zone to create DNS record for this app"
+}
+variable "hostname_create" {
+  default     = "false"
+  description = "Optional parameter to create or not a Route53 record"
+}
+
 variable "hostname" {
   # description = "Hostname(s) to create DNS record for this app, comma-separated"
   description = "Hostname to create DNS record for this app"
@@ -77,6 +86,11 @@ variable "vpc_id" {
 variable "alb_listener_https_arn" {
   description = "ALB HTTPS Listener created by ECS cluster module"
 }
+variable "alb_dns_name" {
+ description = "ALB DNS Name"
+ default= ""
+}
+
 
 variable "alb_priority" {
   default = 0
@@ -136,5 +150,10 @@ variable "healthcheck_timeout" {
 variable "healthcheck_matcher" {
   default     = 200
   description = "The HTTP codes to use when checking for a successful response from a target"
+}
+
+variable "alb-only" {
+  default     = false
+  description = "Whether to deploy only an alb and no cloudFront or not with the cluster"
 }
  

--- a/route53-record.tf
+++ b/route53-record.tf
@@ -3,7 +3,7 @@ data "aws_route53_zone" "selected" {
 }
 
 resource "aws_route53_record" "hostname" {
-  count = "${var.alb-only && var.hostname_create ? 1 : 0}"
+  count = "${var.alb_only && var.hostname_create ? 1 : 0}"
 
   zone_id = data.aws_route53_zone.selected.zone_id
   name    = var.hostname
@@ -13,7 +13,7 @@ resource "aws_route53_record" "hostname" {
 }
 
 resource "aws_route53_record" "hostname_blue" {
-  count = "${var.alb-only ? 1 : 0}"
+  count = "${var.alb_only ? 1 : 0}"
   zone_id = data.aws_route53_zone.selected.zone_id
   name    = var.hostname_blue
   type    = "CNAME"

--- a/route53-record.tf
+++ b/route53-record.tf
@@ -9,7 +9,7 @@ resource "aws_route53_record" "hostname" {
   name    = var.hostname
   type    = "CNAME"
   ttl     = "300"
-  records = list(element(var.alb_dns_name, 0))
+  records = list(var.alb_dns_name))
 }
 
 resource "aws_route53_record" "hostname_blue" {
@@ -18,5 +18,5 @@ resource "aws_route53_record" "hostname_blue" {
   name    = var.hostname_blue
   type    = "CNAME"
   ttl     = "300"
-  records = list(element(var.alb_dns_name, 0))
+  records = list(var.alb_dns_name))
 }

--- a/route53-record.tf
+++ b/route53-record.tf
@@ -1,0 +1,22 @@
+data "aws_route53_zone" "selected" {
+  name = var.hosted_zone
+}
+
+resource "aws_route53_record" "hostname" {
+  count = "${var.alb-only && var.hostname_create ? 1 : 0}"
+
+  zone_id = data.aws_route53_zone.selected.zone_id
+  name    = var.hostname
+  type    = "CNAME"
+  ttl     = "300"
+  records = list(element(var.alb_dns_name, 0))
+}
+
+resource "aws_route53_record" "hostname_blue" {
+  count = "${var.alb-only ? 1 : 0}"
+  zone_id = data.aws_route53_zone.selected.zone_id
+  name    = var.hostname_blue
+  type    = "CNAME"
+  ttl     = "300"
+  records = list(element(var.alb_dns_name, 0))
+}

--- a/route53-record.tf
+++ b/route53-record.tf
@@ -9,7 +9,7 @@ resource "aws_route53_record" "hostname" {
   name    = var.hostname
   type    = "CNAME"
   ttl     = "300"
-  records = list(var.alb_dns_name))
+  records = list(var.alb_dns_name)
 }
 
 resource "aws_route53_record" "hostname_blue" {
@@ -18,5 +18,5 @@ resource "aws_route53_record" "hostname_blue" {
   name    = var.hostname_blue
   type    = "CNAME"
   ttl     = "300"
-  records = list(var.alb_dns_name))
+  records = list(var.alb_dns_name)
 }


### PR DESCRIPTION
Adding alb-only parameter to control a simple stack with no CloudFront and WAF at all.
For this module we have to introduce the reoute53 related parameters:
- hosted_zone
- hostname_create
- alb_dns_name
- alb-only