### PR TITLE
Feat add code deploy route traffic

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,9 @@ This module is designed to be used with `DNXLabs/terraform-aws-ecs`.
 | service\_role\_arn | Existing service role ARN created by ECS cluster module | string | n/a | yes |
 | task\_role\_arn | Existing task role ARN created by ECS cluster module | string | n/a | yes |
 | vpc\_id | VPC ID to deploy this app to | string | n/a | yes |
-
+| codedeploy_wait_time_for_cutover | Time in minutes to route the traffic to the new application deployment | string | `"5"` | no |
+| codedeploy_wait_time_for_termination | Time in minutes to terminate the new deployment | string | `"0"` | no |
+ 
 ## Authors
 
 Module managed by [Allan Denot](https://github.com/adenot).

--- a/_variables.tf
+++ b/_variables.tf
@@ -156,4 +156,12 @@ variable "alb_only" {
   default     = false
   description = "Whether to deploy only an alb and no cloudFront or not with the cluster"
 }
+variable "codedeploy_wait_time_for_cutover" {
+  default     = 5
+  description = "Time in minutes to route the traffic to the new application deployment"
+}
+variable "codedeploy_wait_time_for_termination" {
+  default     = 0
+  description = "Time in minutes to terminate the new deployment"
+}
  

--- a/codedeploy.tf
+++ b/codedeploy.tf
@@ -16,7 +16,7 @@ resource "aws_codedeploy_deployment_group" "ecs" {
 
   blue_green_deployment_config {
     deployment_ready_option {
-      action_on_timeout = "CONTINUE_DEPLOYMENT"
+      action_on_timeout = "STOP_DEPLOYMENT"
       wait_time_in_minutes = "${var.codedeploy_wait_time_for_cutover}"
     }
 

--- a/codedeploy.tf
+++ b/codedeploy.tf
@@ -17,12 +17,12 @@ resource "aws_codedeploy_deployment_group" "ecs" {
   blue_green_deployment_config {
     deployment_ready_option {
       action_on_timeout = "CONTINUE_DEPLOYMENT"
-      wait_time_in_minutes = 5
+      wait_time_in_minutes = "${var.codedeploy_wait_time_for_cutover}"
     }
 
     terminate_blue_instances_on_deployment_success {
       action                           = "TERMINATE"
-      termination_wait_time_in_minutes = 0
+      termination_wait_time_in_minutes = "${var.codedeploy_wait_time_for_termination}"
     }
 
   }

--- a/codedeploy.tf
+++ b/codedeploy.tf
@@ -17,12 +17,14 @@ resource "aws_codedeploy_deployment_group" "ecs" {
   blue_green_deployment_config {
     deployment_ready_option {
       action_on_timeout = "CONTINUE_DEPLOYMENT"
+      wait_time_in_minutes = 5
     }
 
     terminate_blue_instances_on_deployment_success {
       action                           = "TERMINATE"
       termination_wait_time_in_minutes = 0
     }
+
   }
 
   deployment_style {

--- a/route53-record.tf
+++ b/route53-record.tf
@@ -1,11 +1,12 @@
 data "aws_route53_zone" "selected" {
+  count = "${var.alb_only && var.hostname_create ? 1 : 0}"
   name = var.hosted_zone
 }
 
 resource "aws_route53_record" "hostname" {
   count = "${var.alb_only && var.hostname_create ? 1 : 0}"
 
-  zone_id = data.aws_route53_zone.selected.zone_id
+  zone_id = data.aws_route53_zone.selected.*.zone_id[0]
   name    = var.hostname
   type    = "CNAME"
   ttl     = "300"
@@ -14,7 +15,7 @@ resource "aws_route53_record" "hostname" {
 
 resource "aws_route53_record" "hostname_blue" {
   count = "${var.alb_only ? 1 : 0}"
-  zone_id = data.aws_route53_zone.selected.zone_id
+  zone_id = data.aws_route53_zone.selected.*.zone_id[0]
   name    = var.hostname_blue
   type    = "CNAME"
   ttl     = "300"


### PR DESCRIPTION
adding codedeploy_wait_time_for_cutover and codedeploy_wait_time_for_termination to control the route traffic timeout dring deployments