### PR TITLE
add 0 deployment  as default

### DIFF
--- a/_variables.tf
+++ b/_variables.tf
@@ -157,7 +157,7 @@ variable "alb_only" {
   description = "Whether to deploy only an alb and no cloudFront or not with the cluster"
 }
 variable "codedeploy_wait_time_for_cutover" {
-  default     = 5
+  default     = 0
   description = "Time in minutes to route the traffic to the new application deployment"
 }
 variable "codedeploy_wait_time_for_termination" {

--- a/codedeploy.tf
+++ b/codedeploy.tf
@@ -16,13 +16,13 @@ resource "aws_codedeploy_deployment_group" "ecs" {
 
   blue_green_deployment_config {
     deployment_ready_option {
-      action_on_timeout = "STOP_DEPLOYMENT"
-      wait_time_in_minutes = "${var.codedeploy_wait_time_for_cutover}"
+      action_on_timeout = var.codedeploy_wait_time_for_cutover == 0 ? "CONTINUE_DEPLOYMENT" : "STOP_DEPLOYMENT"
+      wait_time_in_minutes = var.codedeploy_wait_time_for_cutover
     }
 
     terminate_blue_instances_on_deployment_success {
       action                           = "TERMINATE"
-      termination_wait_time_in_minutes = "${var.codedeploy_wait_time_for_termination}"
+      termination_wait_time_in_minutes = var.codedeploy_wait_time_for_termination
     }
 
   }


### PR DESCRIPTION
Add 0 minutes as default for traffic route
Add logic to:
If the minutes for cutover is greater than 0
  - apply the timeout termination deploy strategy 