### PR TITLE
#13 Add the ability to find a private hosted zone and create a aws_route53_record (in case the ALB is internal)

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ In addition you have the option to create or not :
 |------|-------------|------|---------|:--------:|
 | alarm\_min\_healthy\_tasks | Alarm when the number of healthy tasks is less than this number (use 0 to disable this alarm) | `number` | `2` | no |
 | alarm\_sns\_topics | Alarm topics to create and alert on ECS service metrics. Leaving empty disables all alarms. | `list` | `[]` | no |
+| alb\_name | ALB Name - Required if it's internal | `string` | `""` | no |
 | alb\_dns\_name | ALB DNS Name | `string` | `""` | no |
 | alb\_listener\_https\_arn | ALB HTTPS Listener created by ECS cluster module | `any` | n/a | yes |
 | alb\_only | Whether to deploy only an alb and no cloudFront or not with the cluster | `bool` | `false` | no |
@@ -86,6 +87,7 @@ In addition you have the option to create or not :
 | healthcheck\_timeout | The amount of time, in seconds, during which no response | `number` | `5` | no |
 | healthy\_threshold | The number of consecutive health checks successes required before considering an unhealthy target healthy | `number` | `3` | no |
 | hosted\_zone | Hosted Zone to create DNS record for this app | `string` | `""` | no |
+| hosted\_zone\_is\_internal | Weather Hosted Zone is internal | `bool` | `"false"` | no |
 | hostname\_create | Optional parameter to create or not a Route53 record | `string` | `"false"` | no |
 | hostname\_redirects | List of hostnames to redirect to the main one, comma-separated | `string` | `""` | no |
 | hostnames | List of hostnames to create listerner rule and optionally, DNS records for this app | `list` | `[]` | no |

--- a/_variables.tf
+++ b/_variables.tf
@@ -28,6 +28,11 @@ variable "paths" {
   type        = list(string)
 }
 
+variable "hosted_zone_is_internal" {
+  default     = "false"
+  description = "Set true in case the hosted zone is in an internal VPC, otherwise false"
+}
+
 variable "hosted_zone" {
   default     = ""
   description = "Hosted Zone to create DNS record for this app"
@@ -111,6 +116,11 @@ variable "test_traffic_route_listener_arn" {
 
 variable "alb_dns_name" {
   description = "ALB DNS Name"
+  default     = ""
+}
+
+variable "alb_name" {
+  description = "ALB name - Required if it is an internal one"
   default     = ""
 }
 

--- a/route53-record.tf
+++ b/route53-record.tf
@@ -14,7 +14,7 @@ resource "aws_route53_record" "hostnames" {
 }
 
 data "aws_lb" "alb_selected" {
-  count = var.alb_only && var.hostname_create && length(var.hostnames) != 0 ? length(var.hostnames) : 0
+  count = var.hosted_zone_is_internal && var.alb_only && var.hostname_create && length(var.hostnames) != 0 ? length(var.hostnames) : 0
   name = var.alb_name
 }
 

--- a/route53-record.tf
+++ b/route53-record.tf
@@ -1,13 +1,31 @@
 data "aws_route53_zone" "selected" {
   count = var.alb_only && var.hostname_create ? 1 : 0
   name  = var.hosted_zone
+  private_zone = var.hosted_zone_is_internal
 }
 
 resource "aws_route53_record" "hostnames" {
-  count   = var.alb_only && var.hostname_create && length(var.hostnames) != 0 ? length(var.hostnames) : 0
+  count   = !var.hosted_zone_is_internal && var.alb_only && var.hostname_create && length(var.hostnames) != 0 ? length(var.hostnames) : 0
   zone_id = data.aws_route53_zone.selected.*.zone_id[0]
   name    = var.hostnames[count.index]
   type    = "CNAME"
   ttl     = "300"
   records = list(var.alb_dns_name)
+}
+
+data "aws_lb" "alb_selected" {
+  count = var.alb_only && var.hostname_create && length(var.hostnames) != 0 ? length(var.hostnames) : 0
+  name = var.alb_name
+}
+
+resource "aws_route53_record" "hostnames_internal" {
+  count   = var.hosted_zone_is_internal && var.alb_only && var.hostname_create && length(var.hostnames) != 0 ? length(var.hostnames) : 0
+  zone_id = data.aws_route53_zone.selected.*.zone_id[0]
+  name    = var.hostnames[count.index]
+  type    = "A"
+  alias {
+    name                   = data.aws_lb.alb_selected.*.dns_name[0]
+    zone_id                = data.aws_lb.alb_selected.*.zone_id[0]
+    evaluate_target_health = true
+  }
 }


### PR DESCRIPTION
2 new variables were added: 
`alb_name` and `hosted_zone_is_internal`

Both variable have to be specified when we want to create a 53 route alias record for the internal ALB.