### PR TITLE
add optional alarm_evaluation_periods

### DIFF
--- a/_variables.tf
+++ b/_variables.tf
@@ -164,6 +164,11 @@ variable "alarm_min_healthy_tasks" {
   description = "Alarm when the number of healthy tasks is less than this number (use 0 to disable this alarm)"
 }
 
+variable "alarm_evaluation_periods" {
+  default     = "2"
+  description = "The number of minutes the alarm must be below the threshold before entering the alarm state."
+}
+
 variable "alarm_sns_topics" {
   default     = []
   description = "Alarm topics to create and alert on ECS service metrics. Leaving empty disables all alarms."

--- a/cloudwatch-alarms.tf
+++ b/cloudwatch-alarms.tf
@@ -3,7 +3,7 @@ resource "aws_cloudwatch_metric_alarm" "min_healthy_tasks" {
 
   alarm_name                = "${data.aws_iam_account_alias.current.account_alias}-ecs-${var.cluster_name}-${var.name}-min-healthy-tasks"
   comparison_operator       = "LessThanThreshold"
-  evaluation_periods        = "2"
+  evaluation_periods        = var.alarm_evaluation_periods
   threshold                 = var.alarm_min_healthy_tasks
   alarm_description         = "Service has less than ${var.alarm_min_healthy_tasks} healthy tasks"
   alarm_actions             = var.alarm_sns_topics


### PR DESCRIPTION
This pull request allows users of the module to set an optional `alarm_evaluation_periods` variable to update how long the min healthy tasks threshold must be exceeded before triggering the alarm. 