### PR TITLE
Update list functions to tolist

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -51,7 +51,7 @@ jobs:
     name: Minimum version check
     runs-on: ubuntu-latest
     container:
-      image: hashicorp/terraform:0.12.0
+      image: hashicorp/terraform:0.13.0
     steps:
       - uses: actions/checkout@master
       - name: Validate Code

--- a/alb-target-group.tf
+++ b/alb-target-group.tf
@@ -85,7 +85,7 @@ resource "aws_lb_listener_rule" "redirects" {
 
   condition {
     host_header {
-      values = list(element(split(",", var.hostname_redirects), count.index))
+      values = tolist([element(split(",", var.hostname_redirects), count.index)])
     }
   }
 }

--- a/codedeploy.tf
+++ b/codedeploy.tf
@@ -40,11 +40,11 @@ resource "aws_codedeploy_deployment_group" "ecs" {
   load_balancer_info {
     target_group_pair_info {
       prod_traffic_route {
-        listener_arns = list(var.alb_listener_https_arn)
+        listener_arns = tolist(var.alb_listener_https_arn)
       }
 
       test_traffic_route {
-        listener_arns = list(var.test_traffic_route_listener_arn)
+        listener_arns = tolist(var.test_traffic_route_listener_arn)
       }
 
       target_group {

--- a/route53-record.tf
+++ b/route53-record.tf
@@ -10,7 +10,7 @@ resource "aws_route53_record" "hostnames" {
   name    = var.hostnames[count.index]
   type    = "CNAME"
   ttl     = "300"
-  records = list(var.alb_dns_name)
+  records = tolist(var.alb_dns_name)
 }
 
 data "aws_lb" "alb_selected" {

--- a/versions.tf
+++ b/versions.tf
@@ -1,3 +1,3 @@
 terraform {
-  required_version = ">= 0.12.0"
+  required_version = ">= 0.13.0"
 }


### PR DESCRIPTION
Signed-off-by: Arthur Diniz <arthurbdiniz@gmail.com>

```
Call to function "list" failed: the "list" function was deprecated in
│ Terraform v0.12 and is no longer available; use tolist([ ... ]) syntax to
│ write a literal list.
```