### PR TITLE
Fix default CPU value causing JSON error due to being string instead of integer

### DIFF
--- a/_variables.tf
+++ b/_variables.tf
@@ -3,12 +3,12 @@ variable "name" {
 }
 
 variable "container_port" {
-  default     = "8080"
+  default     = 8080
   description = "Port your container listens (used in the placeholder task definition)"
 }
 
 variable "port" {
-  default     = "80"
+  default     = 80
   description = "Port for target group to listen"
 }
 


### PR DESCRIPTION
This fixes terraform json marshall error when using the default value

## Types of changes

What types of changes does your code introduce to <repo_name>?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the CONTRIBUTING.md doc.
- [x] I have added necessary documentation (if appropriate).
- [x] Any dependent changes have been merged and published in downstream modules.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...