### PR TITLE
fix: adjust the correct parameter for ECS task placement strategy

### DIFF
--- a/_variables.tf
+++ b/_variables.tf
@@ -325,8 +325,8 @@ variable "ordered_placement_strategy" {
   # This variable may not be used with Fargate!
   description = "Service level strategy rules that are taken into consideration during task placement. List from top to bottom in order of precedence. The maximum number of ordered_placement_strategy blocks is 5."
   type = list(object({
-    field      = string
-    expression = string
+    field = string
+    type  = string
   }))
   default = []
 }


### PR DESCRIPTION
This PR fixes the usage of ECS task placement strategy as described in the [AWS docs](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-placement-strategies.html).