### PR TITLE
Ignoring capacity provider until api or tf is fixed

### DIFF
--- a/ecs-service.tf
+++ b/ecs-service.tf
@@ -50,7 +50,7 @@ resource "aws_ecs_service" "default" {
   }
 
   lifecycle {
-    ignore_changes = [load_balancer, task_definition, desired_count]
+    ignore_changes = [load_balancer, task_definition, desired_count, capacity_provider_strategy]
   }
 
   depends_on = [


### PR DESCRIPTION
Need to ignore until there's a fix from terraform or AWS API.

When creating an ECS Service with a capacity provider, after a deployment, the API will stop returning the capacity provider, causing terraform to try to recreate the resource as it believes there's a drift.

## Types of changes

What types of changes does your code introduce to <repo_name>?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the CONTRIBUTING.md doc.
- [x] I have added necessary documentation (if appropriate).
- [x] Any dependent changes have been merged and published in downstream modules.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...