### PR TITLE
feature: app's ssm parameters creation

### DIFF
--- a/_variables.tf
+++ b/_variables.tf
@@ -466,3 +466,15 @@ variable "redirects" {
   description = "Map of path redirects to add to the listener"
   default     = {}
 }
+
+variable "ssm_parameters_secure_strings" {
+  type        = any
+  default     = []
+  description = "List of app's secure variables to be created in SSM Parameter Store"
+}
+
+variable "ssm_parameters_strings" {
+  type        = any
+  default     = {}
+  description = "List of objects of app's variables to create in SSM Parameter Store"
+}

--- a/ssm.tf
+++ b/ssm.tf
@@ -1,0 +1,23 @@
+resource "aws_ssm_parameter" "secure_string" {
+  for_each    = toset(var.ssm_parameters_secure_strings)
+  name        = "/ecs/${var.cluster_name}/${var.name}/${each.key}"
+  description = each.value
+  type        = "SecureString"
+  value       = "PLACEHOLDER"
+
+  lifecycle {
+    ignore_changes = [value]
+  }
+}
+
+resource "aws_ssm_parameter" "string" {
+  for_each    = var.ssm_parameters_strings
+  name        = "/ecs/${var.cluster_name}/${var.name}/${each.key}"
+  description = each.key
+  type        = "String"
+  value       = each.value
+
+  lifecycle {
+    ignore_changes = [value]
+  }
+}


### PR DESCRIPTION
This PR adds a feature to create app's SSM parameters within the ECS cluster's service creation.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)