### PR TITLE
Made cloudwatch resources optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ In addition you have the option to create or not :
 | autoscaling\_scale\_out\_cooldown | Cooldown in seconds to wait between scale out events | `number` | `300` | no |
 | autoscaling\_target\_cpu | Target average CPU percentage to track for autoscaling | `number` | `50` | no |
 | autoscaling\_target\_memory | Target average Memory percentage to track for autoscaling | `number` | `90` | no |
+| cloudwatch\_logs\_create | Whether to create cloudwatch log resources or not | `bool` | `true` | no |
 | cloudwatch\_logs\_export | Whether to mark the log group to export to an S3 bucket (needs terraform-aws-log-exporter to be deployed in the account/region) | `bool` | `false` | no |
 | cloudwatch\_logs\_retention | Specifies the number of days you want to retain log events in the specified log group. Possible values are: 1, 3, 5, 7, 14, 30, 60, 90, 120, 150, 180, 365, 400, 545, 731, 1827, and 3653. | `number` | `120` | no |
 | cluster\_name | n/a | `string` | `"Name of existing ECS Cluster to deploy this app to"` | no |

--- a/_variables.tf
+++ b/_variables.tf
@@ -257,6 +257,11 @@ variable "codedeploy_deployment_config_name" {
   description = "Specifies the deployment configuration for CodeDeploy"
 }
 
+variable "cloudwatch_logs_create" {
+  default     = true
+  description = "Whether to create cloudwatch log resources or not"
+}
+
 variable "cloudwatch_logs_retention" {
   default     = 120
   description = "Specifies the number of days you want to retain log events in the specified log group. Possible values are: 1, 3, 5, 7, 14, 30, 60, 90, 120, 150, 180, 365, 400, 545, 731, 1827, and 3653."

--- a/cloudwatch-ecs-event-logs.tf
+++ b/cloudwatch-ecs-event-logs.tf
@@ -26,8 +26,8 @@ EOF
 
 resource "aws_cloudwatch_event_target" "ecs_events" {
   count = var.cloudwatch_logs_create ? 1 : 0
-  rule  = aws_cloudwatch_event_rule.ecs_events.name
-  arn   = aws_cloudwatch_log_group.ecs_events.arn
+  rule  = aws_cloudwatch_event_rule.ecs_events[0].name
+  arn   = aws_cloudwatch_log_group.ecs_events[0].arn
 }
 
 data "aws_iam_policy_document" "ecs_events" {
@@ -39,7 +39,7 @@ data "aws_iam_policy_document" "ecs_events" {
       "logs:PutLogEventsBatch",
     ]
 
-    resources = ["${aws_cloudwatch_log_group.ecs_events.arn}:*"]
+    resources = ["${aws_cloudwatch_log_group.ecs_events[0].arn}:*"]
 
     principals {
       identifiers = ["events.amazonaws.com", "delivery.logs.amazonaws.com"]
@@ -50,6 +50,6 @@ data "aws_iam_policy_document" "ecs_events" {
 
 resource "aws_cloudwatch_log_resource_policy" "ecs_events" {
   count           = var.cloudwatch_logs_create ? 1 : 0
-  policy_document = data.aws_iam_policy_document.ecs_events.json
+  policy_document = data.aws_iam_policy_document.ecs_events[0].json
   policy_name     = "capture-ecs-events-${var.cluster_name}-${var.name}"
 }

--- a/cloudwatch-ecs-event-logs.tf
+++ b/cloudwatch-ecs-event-logs.tf
@@ -1,5 +1,5 @@
 resource "aws_cloudwatch_log_group" "ecs_events" {
-  count = var.cloudwatch_logs_create ? 1 : 0
+  count             = var.cloudwatch_logs_create ? 1 : 0
   name              = "/ecs/events/${var.cluster_name}/${var.name}"
   retention_in_days = var.cloudwatch_logs_retention
   tags = {
@@ -9,7 +9,7 @@ resource "aws_cloudwatch_log_group" "ecs_events" {
 
 
 resource "aws_cloudwatch_event_rule" "ecs_events" {
-  count = var.cloudwatch_logs_create ? 1 : 0
+  count         = var.cloudwatch_logs_create ? 1 : 0
   name          = "capture-ecs-events-${var.cluster_name}-${var.name}"
   description   = "Capture ecs service events from ${var.cluster_name}-${var.name}"
   event_pattern = <<EOF
@@ -26,8 +26,8 @@ EOF
 
 resource "aws_cloudwatch_event_target" "ecs_events" {
   count = var.cloudwatch_logs_create ? 1 : 0
-  rule = aws_cloudwatch_event_rule.ecs_events.name
-  arn  = aws_cloudwatch_log_group.ecs_events.arn
+  rule  = aws_cloudwatch_event_rule.ecs_events.name
+  arn   = aws_cloudwatch_log_group.ecs_events.arn
 }
 
 data "aws_iam_policy_document" "ecs_events" {
@@ -49,7 +49,7 @@ data "aws_iam_policy_document" "ecs_events" {
 }
 
 resource "aws_cloudwatch_log_resource_policy" "ecs_events" {
-  count = var.cloudwatch_logs_create ? 1 : 0
+  count           = var.cloudwatch_logs_create ? 1 : 0
   policy_document = data.aws_iam_policy_document.ecs_events.json
   policy_name     = "capture-ecs-events-${var.cluster_name}-${var.name}"
 }

--- a/cloudwatch-ecs-event-logs.tf
+++ b/cloudwatch-ecs-event-logs.tf
@@ -1,4 +1,5 @@
 resource "aws_cloudwatch_log_group" "ecs_events" {
+  count = var.cloudwatch_logs_create ? 1 : 0
   name              = "/ecs/events/${var.cluster_name}/${var.name}"
   retention_in_days = var.cloudwatch_logs_retention
   tags = {
@@ -8,6 +9,7 @@ resource "aws_cloudwatch_log_group" "ecs_events" {
 
 
 resource "aws_cloudwatch_event_rule" "ecs_events" {
+  count = var.cloudwatch_logs_create ? 1 : 0
   name          = "capture-ecs-events-${var.cluster_name}-${var.name}"
   description   = "Capture ecs service events from ${var.cluster_name}-${var.name}"
   event_pattern = <<EOF
@@ -23,11 +25,13 @@ EOF
 }
 
 resource "aws_cloudwatch_event_target" "ecs_events" {
+  count = var.cloudwatch_logs_create ? 1 : 0
   rule = aws_cloudwatch_event_rule.ecs_events.name
   arn  = aws_cloudwatch_log_group.ecs_events.arn
 }
 
 data "aws_iam_policy_document" "ecs_events" {
+  count = var.cloudwatch_logs_create ? 1 : 0
   statement {
     actions = [
       "logs:CreateLogStream",
@@ -45,6 +49,7 @@ data "aws_iam_policy_document" "ecs_events" {
 }
 
 resource "aws_cloudwatch_log_resource_policy" "ecs_events" {
+  count = var.cloudwatch_logs_create ? 1 : 0
   policy_document = data.aws_iam_policy_document.ecs_events.json
   policy_name     = "capture-ecs-events-${var.cluster_name}-${var.name}"
 }


### PR DESCRIPTION
When trying to setup ECS service  it is creating a "aws_cloudwatch_log_resource_policy" which has a hard limit "Up to 10 CloudWatch Logs resource policies per Region per account. This quota can't be changed."
Created variable to optionally not create cloudwatch log resources.

Relevant issue:
https://github.com/DNXLabs/terraform-aws-ecs-app/issues/40

## Types of changes

What types of changes does your code introduce to <repo_name>?
_Put an `x` in the boxes that apply_

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [X] I have read the CONTRIBUTING.md doc.
- [X] I have added necessary documentation (if appropriate).
- [ ] Any dependent changes have been merged and published in downstream modules.
