### PR TITLE
updated  lowercase tags

### DIFF
--- a/ecs-service.tf
+++ b/ecs-service.tf
@@ -62,6 +62,6 @@ resource "aws_ecs_service" "default" {
 
   depends_on = [aws_lb_listener_rule.green]
 
-  tags = merge(var.tags, { "terraform" = "true" }, )
+  tags = merge(var.tags, { "Terraform" = "true" }, )
 
 }

--- a/ecs-task-definition.tf
+++ b/ecs-task-definition.tf
@@ -66,6 +66,6 @@ resource "aws_ecs_task_definition" "default" {
     replace_triggered_by = [aws_lb_target_group.green]
   }
 
-  tags = merge(var.tags, { "terraform" = "true" }, )
+  tags = merge(var.tags, { "Terraform" = "true" }, )
 
 }

--- a/efs-access-point.tf
+++ b/efs-access-point.tf
@@ -13,7 +13,7 @@ resource "aws_efs_access_point" "default" {
   tags = merge(
     var.tags,
     {
-      "terraform" = "true"
+      "Terraform" = "true"
     },
   )
 

--- a/iam-ecs-service.tf
+++ b/iam-ecs-service.tf
@@ -21,7 +21,7 @@ EOF
   tags = merge(
     var.tags,
     {
-      "terraform" = "true"
+      "Terraform" = "true"
     },
   )
 

--- a/iam-ecs-task-attach.tf
+++ b/iam-ecs-task-attach.tf
@@ -34,7 +34,7 @@ resource "aws_iam_policy" "task_role_policy_custom" {
   description = try(each.value.description, "")
   policy      = data.aws_iam_policy_document.task_role_policy_custom[each.value.name].json
 
-  tags = merge(var.tags, { "terraform" = "true" }, )
+  tags = merge(var.tags, { "Terraform" = "true" }, )
 }
 
 resource "aws_iam_role_policy_attachment" "task_role_attach_policy_custom" {

--- a/iam-ecs-task.tf
+++ b/iam-ecs-task.tf
@@ -18,7 +18,7 @@ resource "aws_iam_role" "ecs_task" {
 }
 EOF
 
-  tags = merge(var.tags, { "terraform" = "true" }, )
+  tags = merge(var.tags, { "Terraform" = "true" }, )
 }
 
 resource "aws_iam_role_policy_attachment" "ecs_task" {


### PR DESCRIPTION
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

This PR fixes a tagging conflict related to case sensitivity in IAM role tagging. Currently, the module hardcodes the tag key "terraform" = "true", which can cause Duplicate tag keys found errors during deployment if the user also sets "Terraform" = "true" in var.tags. Since AWS IAM tag keys are case-insensitive, this results in a 400 error from the API.

This change standardizes the casing of the hardcoded tag key from "terraform" to "Terraform" to align with common Terraform tagging practices and prevent case collision errors when merging user-defined tags.

What types of changes does your code introduce to <repo_name>?
_Put an `x` in the boxes that apply_

- [ x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the CONTRIBUTING.md doc.
- [x] I have added necessary documentation (if appropriate).
- [x] Any dependent changes have been merged and published in downstream modules.

## Further comments
This is a small but important fix to prevent deployment issues when users provide tag keys like "Terraform" that collide (case-insensitively) with the module’s hardcoded "terraform" tag.
